### PR TITLE
fix: fix mkdir if the dir already exists

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -19,7 +19,7 @@ runs:
   using: 'composite'
   steps:
     - name: Create temporary directory to store the CLI
-      run: mkdir /tmp/tx
+      run: mkdir -p /tmp/tx
       shell: bash
     - name: Download the CLI
       run: curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash -s -- ${{ inputs.version }}


### PR DESCRIPTION
Add parents option on the mkdir command to avoid issue if someone use the action twice in the same github action.

Extract from the mkdir man:

>       -p, --parents
>              no error if existing, make parent directories as needed

For the record, I got the issue here: https://github.com/GreatWizard/lan-play-status/actions/runs/4393468175/jobs/7693881509