### PR TITLE
fix: download tx only if not yet existing

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,7 @@ runs:
       run: mkdir -p /tmp/tx
       shell: bash
     - name: Download the CLI
+      if: ${{ hashFiles('/tmp/tx/tx') == '' }}
       run: curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash -s -- ${{ inputs.version }}
       working-directory: /tmp/tx
       shell: bash


### PR DESCRIPTION
This can be the case when the action is called multiple times in the same job

![Screenshot from 2024-09-04 16-12-56](https://github.com/user-attachments/assets/d6458774-33f9-45ec-9794-28bcefab824a)
